### PR TITLE
Add missing test dependency to Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,8 +8,9 @@ LuxurySparse = "d05aeea4-b7d4-55ac-b691-9e7fabb07ba2"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SparseArrays"]
+test = ["Test", "SparseArrays", "Random"]


### PR DESCRIPTION
Random is used in the tests but is not declared as a test dependency. Noticed while checking for package testing regressions for the upcoming Julia 1.2 release.