### PR TITLE
add `SubDitStr` function to enable `DitStr` slicing

### DIFF
--- a/src/BitBasis.jl
+++ b/src/BitBasis.jl
@@ -6,6 +6,7 @@ export bitarray, basis, packbits, bfloat, bfloat_r, bint, bint_r, flip
 export anyone, allone, bmask, baddrs, readbit, setbit, controller
 export swapbits, ismatch, neg, breflect, btruncate
 export LongLongUInt
+export SubDitStr
 
 include("utils.jl")
 include("longlonguint.jl")

--- a/src/DitStr.jl
+++ b/src/DitStr.jl
@@ -1,5 +1,5 @@
-const UIntStorage = Union{UInt8,UInt16,UInt32,UInt64,UInt128,LongLongUInt}
-const IntStorage = Union{Int8,Int16,Int32,Int64,Int128,BigInt,UIntStorage}
+const UIntStorage = Union{UInt8, UInt16, UInt32, UInt64, UInt128, LongLongUInt}
+const IntStorage = Union{Int8, Int16, Int32,Int64,Int128,BigInt,UIntStorage}
 
 ########## DitStr #########
 """
@@ -170,6 +170,10 @@ The struct as a `SubString`-like object for `DitStr`(`SubString` is an official 
     SubDitStr(dit::DitStr{D,N,T}, i::Int, j::Int)
     SubDitStr(dit::DitStr{D,N,T}, r::AbstractUnitRange{<:Integer})
 
+Or by `@views` macro for `DitStr` (this macro makes your life easier by supporting `begin` and `end` syntax):
+
+    @views dit[i:j]
+
 Returns a `SubDitStr`.
 
 ### Examples
@@ -180,6 +184,9 @@ julia> x = DitStr{3, 5}(71)
 
 julia> sx =  SubDitStr(x, 2, 4) 
 SubDitStr{3, 5, Int64}(02122 ₍₃₎, 1, 3)
+
+julia> @views x[2:end] 
+SubDitStr{3, 5, Int64}(02122 ₍₃₎, 1, 4)
 
 julia> sx == dit"212;3"
 true
@@ -199,6 +206,10 @@ struct SubDitStr{D,N,T<:Integer} <: Integer
         return new{D,N,T}(dit, i - 1, j - i + 1)
     end
 end
+
+Base.@propagate_inbounds Base.view(dit::DitStr{D,N,T}, i::Integer, j::Integer) where {D,N,T} = SubDitStr(dit, i, j)
+Base.@propagate_inbounds Base.view(dit::DitStr{D,N,T}, r::AbstractUnitRange{<:Integer}) where {D,N,T} = SubDitStr(dit, first(r), last(r))
+Base.@propagate_inbounds Base.maybeview(dit::DitStr{D,N,T}, r::AbstractUnitRange{<:Integer}) where {D,N,T} = view(dit,r) 
 
 """
     DitStr(dit::SubDitStr{D,N,T}) -> DitStr{D,N,T}

--- a/test/DitStr.jl
+++ b/test/DitStr.jl
@@ -41,4 +41,16 @@ end
     @test dit"210;3" == sx
     @test DitStr(sx) == dit"210;3"
     @test SubDitStr(dit"210;3",1,length(dit"210;3")) == sx
+    @test (@views x[4:end]) == dit"112;3"
+    @test (@views x[begin:3]) == dit"100;3"   
+end
+
+using BenchmarkTools
+
+function bm()
+    # test performance in slicing
+    a = LongBitStr(ones(Bool, 200))
+    @btime LongBitStr($a[1:100]) # 3.925 μs (14 allocations: 1.42 KiB)
+    @btime SubDitStr($a, 1, 100) # 1.600 ns (0 allocations: 0 bytes) 
+    @btime DitStr(SubDitStr($a, 1, 100)) # 2.722 μs (4 allocations: 192 bytes)
 end

--- a/test/DitStr.jl
+++ b/test/DitStr.jl
@@ -45,11 +45,12 @@ end
     @test (@views x[begin:3]) == dit"100;3"   
 end
 
+# using BenchmarkTools
 
-function bm()
-    # test performance in slicing
-    a = LongBitStr(ones(Bool, 200))
-    @btime LongBitStr($a[1:100]) # 3.925 μs (14 allocations: 1.42 KiB)
-    @btime SubDitStr($a, 1, 100) # 1.600 ns (0 allocations: 0 bytes) 
-    @btime DitStr(SubDitStr($a, 1, 100)) # 2.722 μs (4 allocations: 192 bytes)
-end
+# function bm()
+#     # test performance in slicing
+#     a = LongBitStr(ones(Bool, 200))
+#     @btime LongBitStr($a[1:100]) # 3.925 μs (14 allocations: 1.42 KiB)
+#     @btime SubDitStr($a, 1, 100) # 1.600 ns (0 allocations: 0 bytes) 
+#     @btime DitStr(SubDitStr($a, 1, 100)) # 2.722 μs (4 allocations: 192 bytes)
+# end

--- a/test/DitStr.jl
+++ b/test/DitStr.jl
@@ -45,7 +45,6 @@ end
     @test (@views x[begin:3]) == dit"100;3"   
 end
 
-using BenchmarkTools
 
 function bm()
     # test performance in slicing

--- a/test/DitStr.jl
+++ b/test/DitStr.jl
@@ -44,11 +44,3 @@ end
     @test (@views x[4:end]) == dit"112;3"
     @test (@views x[begin:3]) == dit"100;3"   
 end
-
-# function bm()
-#     # test performance in slicing
-#     a = LongBitStr(ones(Bool, 200))
-#     @btime LongBitStr($a[1:100]) # 3.925 μs (14 allocations: 1.42 KiB)
-#     @btime SubDitStr($a, 1, 100) # 1.600 ns (0 allocations: 0 bytes) 
-#     @btime DitStr(SubDitStr($a, 1, 100)) # 2.722 μs (4 allocations: 192 bytes)
-# end

--- a/test/DitStr.jl
+++ b/test/DitStr.jl
@@ -45,8 +45,6 @@ end
     @test (@views x[begin:3]) == dit"100;3"   
 end
 
-# using BenchmarkTools
-
 # function bm()
 #     # test performance in slicing
 #     a = LongBitStr(ones(Bool, 200))

--- a/test/DitStr.jl
+++ b/test/DitStr.jl
@@ -39,5 +39,6 @@ end
     @test length(sx) == 3
     @test sx == dit"210;3"
     @test dit"210;3" == sx
+    @test DitStr(sx) == dit"210;3"
     @test SubDitStr(dit"210;3",1,length(dit"210;3")) == sx
 end

--- a/test/DitStr.jl
+++ b/test/DitStr.jl
@@ -5,14 +5,14 @@ using BitBasis, Test
     @test x isa DitStr
     @test x |> length == 6
     println(x)
-    @test buffer(x) === Int64(3^5 + 3^4 + 2*3^3 + 3^2)
+    @test buffer(x) === Int64(3^5 + 3^4 + 2 * 3^3 + 3^2)
     @test_throws ErrorException randn(100)[x]
     @test BitBasis.readat(x, 2) == Int64(0)
     @test x[2] == Int64(0)
     @test x[3] == Int64(1)
     @test x[4] == Int64(2)
-    @test [x...] == Int64[0,0,1,2,1,1]
-    @test [DitStr{3}(Int64[0,0,1,2,1,1])...] == Int64[0,0,1,2,1,1]
+    @test [x...] == Int64[0, 0, 1, 2, 1, 1]
+    @test [DitStr{3}(Int64[0, 0, 1, 2, 1, 1])...] == Int64[0, 0, 1, 2, 1, 1]
     @test_throws ErrorException BitBasis.parse_dit(Int64, "112103;3")
     @test_throws ErrorException BitBasis.parse_dit(Int64, "112101;")
 
@@ -24,4 +24,20 @@ using BitBasis, Test
     @test_throws ErrorException BitBasis.parse_dit(Int64, "12341111111111111111111111111111111111111111111111111111111;5")
 
     @test hash(x) isa UInt64
+end
+
+@testset "SubDitStr" begin
+    x = dit"112100;3"
+    sx = SubDitStr(x, 2, 4) # bit"210"
+    @test_throws BoundsError SubDitStr(x, 2, 7)
+    @test checkbounds(sx, 1) == nothing
+    @test getindex(sx, 1) == 0
+    @test getindex(sx, 2) == 1
+    @test getindex(sx, 3) == 2
+    @test_throws BoundsError getindex(sx, 4)
+    @test_throws BoundsError getindex(sx, 0)
+    @test length(sx) == 3
+    @test sx == dit"210;3"
+    @test dit"210;3" == sx
+    @test SubDitStr(dit"210;3",1,length(dit"210;3")) == sx
 end


### PR DESCRIPTION
I studied the official implementation of `SubStrings` in Julia's Base library [SubString.jl](https://github.com/JuliaLang/julia/blob/48d4fd48430af58502699fdf3504b90589df3852/base/strings/substring.jl)

I think same implementation can be added into `BitBasis.jl` for high performance slicing, so I imitated the implementation in the Base Library in this PR