### PR TITLE
dispatch operation on LongLongUInt{1} to UInt

### DIFF
--- a/src/longlonguint.jl
+++ b/src/longlonguint.jl
@@ -29,6 +29,35 @@ function Base.mod(x::LongLongUInt{C}, D::Int) where {C}
     D == 2 ? mod(x.content[end], 2) : error("mod only supports 2")
 end
 
+function Base.:(>>)(x::LongLongUInt{1}, y::Int)
+    return LongLongUInt{1}(x.content[1] >> y)
+end
+function Base.:(<<)(x::LongLongUInt{1}, y::Int)
+    return LongLongUInt{1}(x.content[1] << y)
+end
+
+function readbit(x::LongLongUInt{1}, loc::Int)
+    return readbit(x.content[1], loc)
+end
+function indicator(::Type{LongLongUInt{1}}, i::Int)
+    return LongLongUInt{1}(indicator(UInt, i))
+end
+
+function Base.:(<)(val1::LongLongUInt{1}, val2::LongLongUInt{1})
+    return val1.content[1] < val2.content[1]
+end
+
+function Base.:(<)(val1::LongLongUInt{C}, val2::LongLongUInt{C}) where{C}
+    for i in 1:C
+        if val1.content[i] < val2.content[i]
+            return true
+        elseif val1.content[i] > val2.content[i]
+            return false
+        end
+    end
+    return false
+end
+
 function Base.:(>>)(x::LongLongUInt{C}, y::Int) where {C}
     y < 0 && return x << -y
     nshift = y ÷ bsizeof(UInt)
@@ -103,4 +132,6 @@ function longinttype(n::Int, D::Int)
     C = (N-1) ÷ bsizeof(UInt) + 1
     return LongLongUInt{C}
 end
-Base.hash(x::LongLongUInt) = hash(x.content)
+
+Base.hash(x::LongLongUInt{1}) = hash(x.content[1])
+Base.hash(x::LongLongUInt{C}) where{C} = hash(x.content)

--- a/test/longlonguint.jl
+++ b/test/longlonguint.jl
@@ -37,6 +37,11 @@ using Test, BitBasis
 end
 
 @testset "shift" begin
+    x = LongLongUInt((3, ))
+    @test x << 0 == LongLongUInt((3, ))
+    @test x << 1 == LongLongUInt((3 << 1, ))
+    @test x >> 1 == LongLongUInt((3 >> 1, ))
+
     x = LongLongUInt((3, 6))
     @test x << 0 == LongLongUInt((3, 6))
     @test x << 64 == LongLongUInt((6, 0))
@@ -70,6 +75,12 @@ end
 end
 
 @testset "takebit" begin
+    x = LongLongUInt((3,))
+    @test readbit(x, 1) == 1
+    @test readbit(x, 2) == 1
+    @test readbit(x, 3) == 0
+    @test readbit(x, 4) == 0
+
     x = LongLongUInt((3, 6))
     @test readbit(x, 1) == 0
     @test readbit(x, 2) == 1
@@ -86,4 +97,27 @@ end
 @testset "bmask" begin
     @test bmask(LongLongUInt{1}, 1:1) == LongLongUInt((UInt64(1),))
     @test bmask(LongLongUInt{2}, 1:65) == LongLongUInt((UInt64(1), typemax(UInt64)))
+end
+
+@testset "isless" begin
+    x = LongLongUInt((3,))
+    y = LongLongUInt((5,))
+    @test x < y
+    @test y > x
+
+    x = LongLongUInt((3, 6))
+    y = LongLongUInt((3, 7))
+    @test x < y
+    @test y > x
+
+    x = LongLongUInt((3, 6))
+    y = LongLongUInt((3, 6))
+    @test !(x < y)
+    @test !(y < x)
+    @test x ≥ y
+    @test y ≥ x
+
+    xs = [LongLongUInt((3, 6)), LongLongUInt((3, 7)), LongLongUInt((2, 4))]
+    sorted_xs = sort(xs)
+    @test sorted_xs == [LongLongUInt((2, 4)), LongLongUInt((3, 6)), LongLongUInt((3, 7))]
 end


### PR DESCRIPTION
Operations on ` LongLongUInt{1} ` is slower that directly use operation on `Uint`, dispatch them to functions of `UInt`.
Now the performance is shown below:
```Julia
julia> using BitBasis, BenchmarkTools

julia> b1 = bmask(LongLongUInt{1}, 1:10)
LongLongUInt{1}((0x00000000000003ff,))

julia> b2 = bmask(UInt, 1:10)
0x00000000000003ff

julia> @btime $b1 << 1
  1.375 ns (0 allocations: 0 bytes)
LongLongUInt{1}((0x00000000000007fe,))

julia> @btime $b2 << 1
  1.375 ns (0 allocations: 0 bytes)
0x00000000000007fe

julia> @btime readbit($b1, 10)
  1.375 ns (0 allocations: 0 bytes)
0x0000000000000001

julia> @btime readbit($b2, 10)
  1.375 ns (0 allocations: 0 bytes)
0x0000000000000001
```