### PR TITLE
fix the function `_ssub`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,24 +22,15 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info

--- a/src/longlonguint.jl
+++ b/src/longlonguint.jl
@@ -117,7 +117,7 @@ end
 function _ssub(x::NTuple{C,UInt}, y::NTuple{C,UInt}, c::Bool) where {C}
     v1, c1 = Base.sub_with_overflow(x[C], y[C])
     if c
-        v2, c2 = Base.sub_with_overflow(v1, c)
+        v2, c2 = Base.sub_with_overflow(v1, one(UInt))
         c = c1 || c2
         return (_ssub(x[1:C-1], y[1:C-1], c)..., v2)
     else

--- a/test/longlonguint.jl
+++ b/test/longlonguint.jl
@@ -35,6 +35,8 @@ using Test, BitBasis
     BitBasis.max_num_elements(LongLongUInt{2}, 4) == 40
     BitBasis.max_num_elements(UInt, 2) == 64
     BitBasis.max_num_elements(Int, 2) == 63
+
+    @test count_ones(bmask(LongLongUInt{50}, 1:3000)) == 3000
 end
 
 @testset "shift" begin


### PR DESCRIPTION
In the current code the function `_ssub` for `LongLongUInt` is not correct.
```julia
function _ssub(x::NTuple{C,UInt}, y::NTuple{C,UInt}, c::Bool) where {C}
    v1, c1 = Base.sub_with_overflow(x[C], y[C])
    if c
        v2, c2 = Base.sub_with_overflow(v1, c)
        c = c1 || c2
        return (_ssub(x[1:C-1], y[1:C-1], c)..., v2)
    else
        return (_ssub(x[1:C-1], y[1:C-1], c1)..., v1)
    end
end
```
when `c == true`, it calls `Base.sub_with_overflow(v1, c)`, where `v1` is `UInt` and `c` is `Bool`. This function is not supported.

I change the function call to be `Base.sub_with_overflow(v1, one(c))` to fix that.